### PR TITLE
Keep codecov-action

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -364,19 +364,16 @@ jobs:
         name: errors
         path: Tests/errors
 
+    - name: Prepare coverage token
+      if: success() && github.repository == 'python-pillow/Pillow'
+      run: cp .github/codecov-upstream.yml .codecov.yml
+
     - name: Upload coverage
       if: success()
-      run: |
-        if [ "$GITHUB_REPOSITORY" == "python-pillow/Pillow" ]; then
-          echo "CI on python-pillow/Pillow, copy CodeCov settings"
-          cp .github/codecov-upstream.yml .codecov.yml
-        fi
-        echo Upload coverage
-        curl -s https://codecov.io/bash | bash
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        CODECOV_NAME: ${{ runner.os }} Python ${{ matrix.python-version }}
-      shell: bash
+      uses: codecov/codecov-action@v1
+      with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: ${{ runner.os }} Python ${{ matrix.python-version }}
 
     - name: Build wheel
       id: wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,14 +97,13 @@ jobs:
         MATRIX_OS: ${{ matrix.os }}
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
+    - name: Prepare coverage token
+      if: success() && github.repository == 'python-pillow/Pillow'
+      run: cp .github/codecov-upstream.yml .codecov.yml
+
     - name: Upload coverage
       if: success()
-      run: |
-        if [ "$GITHUB_REPOSITORY" == "python-pillow/Pillow" ]; then
-          echo "CI on python-pillow/Pillow, copy CodeCov settings"
-          cp .github/codecov-upstream.yml .codecov.yml
-        fi
-        bash <(curl -s https://codecov.io/bash)
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        CODECOV_NAME: ${{ matrix.os }} Python ${{ matrix.python-version }}
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        name: ${{ matrix.os }} Python ${{ matrix.python-version }}


### PR DESCRIPTION
Maybe you've already considered this, but this PR moves the copy operation into a separate step, so that "Upload coverage" goes back to using codecov/codecov-action@v1, which is simpler.