### PR TITLE
Rearranged code for Windows

### DIFF
--- a/Tests/test_file_im.py
+++ b/Tests/test_file_im.py
@@ -72,12 +72,15 @@ def test_eoferror():
 
 
 def test_roundtrip(tmp_path):
-    for mode in ["RGB", "P", "PA"]:
+    def roundtrip(mode):
         out = str(tmp_path / "temp.im")
         im = hopper(mode)
         im.save(out)
         with Image.open(out) as reread:
             assert_image_equal(reread, im)
+
+    for mode in ["RGB", "P", "PA"]:
+        roundtrip(mode)
 
 
 def test_save_unsupported_mode(tmp_path):


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/4424

Why was the test failing? I would guess something to do with https://docs.python.org/3/library/tempfile.html
> Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows NT or later).

Why does this change made the test pass? I don't know.