### PR TITLE
Raise a DeprecationWarning when comparing PILLOW_VERSION

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import tempfile
 
+import PIL
 import pytest
 from PIL import Image, ImageDraw, ImagePalette, UnidentifiedImageError
 
@@ -607,6 +608,13 @@ class TestImage:
                 im.load()
 
             assert not fp.closed
+
+    def test_pillow_version(self):
+        with pytest.warns(DeprecationWarning):
+            assert PIL.__version__ == PIL.PILLOW_VERSION
+
+        with pytest.warns(DeprecationWarning):
+            assert int(PIL.PILLOW_VERSION[0]) >= 7
 
     def test_overrun(self):
         for file in [

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -611,10 +611,28 @@ class TestImage:
 
     def test_pillow_version(self):
         with pytest.warns(DeprecationWarning):
-            assert PIL.__version__ == PIL.PILLOW_VERSION
+            assert PIL.PILLOW_VERSION == PIL.__version__
+
+        with pytest.warns(DeprecationWarning):
+            str(PIL.PILLOW_VERSION)
 
         with pytest.warns(DeprecationWarning):
             assert int(PIL.PILLOW_VERSION[0]) >= 7
+
+        with pytest.warns(DeprecationWarning):
+            assert PIL.PILLOW_VERSION < "9.9.0"
+
+        with pytest.warns(DeprecationWarning):
+            assert PIL.PILLOW_VERSION <= "9.9.0"
+
+        with pytest.warns(DeprecationWarning):
+            assert PIL.PILLOW_VERSION != "7.0.0"
+
+        with pytest.warns(DeprecationWarning):
+            assert PIL.PILLOW_VERSION >= "7.0.0"
+
+        with pytest.warns(DeprecationWarning):
+            assert PIL.PILLOW_VERSION > "7.0.0"
 
     def test_overrun(self):
         for file in [

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -609,30 +609,33 @@ class TestImage:
 
             assert not fp.closed
 
-    def test_pillow_version(self):
+    @pytest.mark.parametrize(
+        "test_module", [PIL, Image],
+    )
+    def test_pillow_version(self, test_module):
         with pytest.warns(DeprecationWarning):
-            assert PIL.PILLOW_VERSION == PIL.__version__
+            assert test_module.PILLOW_VERSION == PIL.__version__
 
         with pytest.warns(DeprecationWarning):
-            str(PIL.PILLOW_VERSION)
+            str(test_module.PILLOW_VERSION)
 
         with pytest.warns(DeprecationWarning):
-            assert int(PIL.PILLOW_VERSION[0]) >= 7
+            assert int(test_module.PILLOW_VERSION[0]) >= 7
 
         with pytest.warns(DeprecationWarning):
-            assert PIL.PILLOW_VERSION < "9.9.0"
+            assert test_module.PILLOW_VERSION < "9.9.0"
 
         with pytest.warns(DeprecationWarning):
-            assert PIL.PILLOW_VERSION <= "9.9.0"
+            assert test_module.PILLOW_VERSION <= "9.9.0"
 
         with pytest.warns(DeprecationWarning):
-            assert PIL.PILLOW_VERSION != "7.0.0"
+            assert test_module.PILLOW_VERSION != "7.0.0"
 
         with pytest.warns(DeprecationWarning):
-            assert PIL.PILLOW_VERSION >= "7.0.0"
+            assert test_module.PILLOW_VERSION >= "7.0.0"
 
         with pytest.warns(DeprecationWarning):
-            assert PIL.PILLOW_VERSION > "7.0.0"
+            assert test_module.PILLOW_VERSION > "7.0.0"
 
     def test_overrun(self):
         for file in [

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -42,18 +42,32 @@ from pathlib import Path
 # PILLOW_VERSION is deprecated and will be removed in a future release.
 # Use __version__ instead.
 from . import (
-    PILLOW_VERSION,
     ImageMode,
     TiffTags,
     UnidentifiedImageError,
     __version__,
     _plugins,
+    _raise_version_warning,
 )
 from ._binary import i8, i32le
 from ._util import deferred_error, isPath
 
-# Silence warning
-assert PILLOW_VERSION
+if sys.version_info >= (3, 7):
+
+    def __getattr__(name):
+        if name == "PILLOW_VERSION":
+            _raise_version_warning()
+            return __version__
+        raise AttributeError("module '{}' has no attribute '{}'".format(__name__, name))
+
+
+else:
+
+    from . import PILLOW_VERSION
+
+    # Silence warning
+    assert PILLOW_VERSION
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -13,6 +13,7 @@ Use PIL.__version__ for this Pillow version.
 ;-)
 """
 
+import sys
 import warnings
 
 from . import _version
@@ -21,27 +22,62 @@ from . import _version
 __version__ = _version.__version__
 
 
-class _Deprecated_Version(str):
-    def _raise_warning(self):
-        warnings.warn(
-            "PILLOW_VERSION is deprecated and will be removed in a future release. "
-            "Use __version__ instead.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-
-    def __getitem__(self, key):
-        self._raise_warning()
-        return super().__getitem__(key)
-
-    def __eq__(self, other):
-        self._raise_warning()
-        return super().__eq__(other)
-
-
 # PILLOW_VERSION is deprecated and will be removed in a future release.
 # Use __version__ instead.
-PILLOW_VERSION = _Deprecated_Version(__version__)
+def _raise_version_warning():
+    warnings.warn(
+        "PILLOW_VERSION is deprecated and will be removed in a future release. "
+        "Use __version__ instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+if sys.version_info >= (3, 7):
+
+    def __getattr__(name):
+        if name == "PILLOW_VERSION":
+            _raise_version_warning()
+            return __version__
+        raise AttributeError("module '{}' has no attribute '{}'".format(__name__, name))
+
+
+else:
+
+    class _Deprecated_Version(str):
+        def __str__(self):
+            _raise_version_warning()
+            return super().__str__()
+
+        def __getitem__(self, key):
+            _raise_version_warning()
+            return super().__getitem__(key)
+
+        def __eq__(self, other):
+            _raise_version_warning()
+            return super().__eq__(other)
+
+        def __ne__(self, other):
+            _raise_version_warning()
+            return super().__ne__(other)
+
+        def __gt__(self, other):
+            _raise_version_warning()
+            return super().__gt__(other)
+
+        def __lt__(self, other):
+            _raise_version_warning()
+            return super().__lt__(other)
+
+        def __ge__(self, other):
+            _raise_version_warning()
+            return super().__gt__(other)
+
+        def __le__(self, other):
+            _raise_version_warning()
+            return super().__lt__(other)
+
+    PILLOW_VERSION = _Deprecated_Version(__version__)
 
 del _version
 

--- a/src/PIL/__init__.py
+++ b/src/PIL/__init__.py
@@ -13,12 +13,35 @@ Use PIL.__version__ for this Pillow version.
 ;-)
 """
 
+import warnings
+
 from . import _version
 
 # VERSION was removed in Pillow 6.0.0.
+__version__ = _version.__version__
+
+
+class _Deprecated_Version(str):
+    def _raise_warning(self):
+        warnings.warn(
+            "PILLOW_VERSION is deprecated and will be removed in a future release. "
+            "Use __version__ instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+    def __getitem__(self, key):
+        self._raise_warning()
+        return super().__getitem__(key)
+
+    def __eq__(self, other):
+        self._raise_warning()
+        return super().__eq__(other)
+
+
 # PILLOW_VERSION is deprecated and will be removed in a future release.
 # Use __version__ instead.
-PILLOW_VERSION = __version__ = _version.__version__
+PILLOW_VERSION = _Deprecated_Version(__version__)
 
 del _version
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/4494 - creates a class that inherits from `str` and raises a warning when used in common ways.