### PR TITLE
Raise DeprecationWarning on raise_ioerror

### DIFF
--- a/Tests/test_imagefile.py
+++ b/Tests/test_imagefile.py
@@ -93,6 +93,11 @@ class TestImageFile:
 
         assert_image_equal(im1, im2)
 
+    def test_raise_ioerror(self):
+        with pytest.raises(IOError):
+            with pytest.raises(DeprecationWarning):
+                ImageFile.raise_ioerror(1)
+
     def test_raise_oserror(self):
         with pytest.raises(OSError):
             ImageFile.raise_oserror(1)

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -12,6 +12,15 @@ Deprecated features
 Below are features which are considered deprecated. Where appropriate,
 a ``DeprecationWarning`` is issued.
 
+ImageFile.raise_ioerror
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. deprecated:: 7.2.0
+
+IOError was merged into OSError in Python 3.3. So, ``ImageFile.raise_ioerror``
+is now deprecated and will be removed in a future released. Use
+``ImageFile.raise_oserror`` instead.
+
 PILLOW_VERSION constant
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -17,7 +17,7 @@ ImageFile.raise_ioerror
 
 .. deprecated:: 7.2.0
 
-IOError was merged into OSError in Python 3.3. So, ``ImageFile.raise_ioerror``
+``IOError`` was merged into ``OSError`` in Python 3.3. So, ``ImageFile.raise_ioerror``
 is now deprecated and will be removed in a future released. Use
 ``ImageFile.raise_oserror`` instead.
 

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -30,6 +30,7 @@
 import io
 import struct
 import sys
+import warnings
 
 from . import Image
 from ._util import isPath
@@ -62,6 +63,15 @@ def raise_oserror(error):
     if not message:
         message = "decoder error %d" % error
     raise OSError(message + " when reading image file")
+
+
+def raise_ioerror(error):
+    warnings.warn(
+        "raise_ioerror is deprecated and will be removed in a future release. "
+        "Use raise_oserror instead.",
+        DeprecationWarning,
+    )
+    return raise_oserror(error)
 
 
 def _tilesort(t):


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/4536

This is in support of 1, keep `raise_ioerror` and raise a deprecation warning.

I was thinking that 2, making it private, would be not ideal if someone was creating their own plugin and found some need for it.

Then I found that TiffImagePlugin raises an OSError in the same way that ImageFile does/will - https://github.com/python-pillow/Pillow/blob/a8a4b9bfdbf36ab964f57b34d1e1733d232b6175/src/PIL/TiffImagePlugin.py#L1181-L1182. If not for the fact that we are concerned with backwards compatibility, I'd suggest we change the TiffImagePlugin line from `raise OSError(err)` to `ImageFile.raise_oserror(err)`.

So yes, I think the `raise_oserror` function could still be useful external to `ImageFile`.