### PR TITLE
Initialise __loaded = 0, removed initialisation of __physical_frame

### DIFF
--- a/Tests/test_pickle.py
+++ b/Tests/test_pickle.py
@@ -84,6 +84,7 @@ def test_pickle_la_mode_with_palette(tmp_path):
         assert im == loaded_im
 
 
+@skip_unless_feature("webp")
 def test_pickle_tell():
     # Arrange
     image = Image.open("Tests/images/hopper.webp")

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -38,9 +38,8 @@ class WebPImageFile(ImageFile.ImageFile):
 
     format = "WEBP"
     format_description = "WebP image"
-    __loaded = -1
+    __loaded = 0
     __logical_frame = 0
-    __physical_frame = 0
 
     def _open(self):
         if not _webp.HAVE_WEBPANIM:


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/4561

Thanks for the PR.

[`tobytes()` is called when pickling an image](https://github.com/python-pillow/Pillow/blob/e4fa234340f5b4c583bd17db7037ef560aa92e5f/src/PIL/Image.py#L690-L691),  so that means [it is loaded](https://github.com/python-pillow/Pillow/blob/e4fa234340f5b4c583bd17db7037ef560aa92e5f/src/PIL/Image.py#L705-L729). As a result, I don't think we need to call `_open` like [you suggested](https://github.com/python-pillow/Pillow/pull/4561#discussion_r410067067).

When you set `__loaded = -1` in this PR, I'm guessing you were looking at [`_reset`](https://github.com/python-pillow/Pillow/blob/e4fa234340f5b4c583bd17db7037ef560aa92e5f/src/PIL/WebPImagePlugin.py#L119-L123). But as I'm saying here, an unpickled image isn't reset, it's loaded. So that means that [`self.__loaded = self.__logical_frame`](https://github.com/python-pillow/Pillow/blob/e4fa234340f5b4c583bd17db7037ef560aa92e5f/src/PIL/WebPImagePlugin.py#L154-L163).

And with that, this PR should pass.