### PR TITLE
Simplified code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -418,10 +418,8 @@ class pil_build_ext(build_ext):
                 for d in os.environ[k].split(os.path.pathsep):
                     _add_directory(library_dirs, d)
 
-        prefix = os.path.normpath(sys.prefix)
-        if prefix:
-            _add_directory(library_dirs, os.path.join(prefix, "lib"))
-            _add_directory(include_dirs, os.path.join(prefix, "include"))
+        _add_directory(library_dirs, os.path.join(sys.prefix, "lib"))
+        _add_directory(include_dirs, os.path.join(sys.prefix, "include"))
 
         #
         # add platform directories


### PR DESCRIPTION
Two suggested changes here.

1.
```python
prefix = os.path.normpath(sys.prefix)
if prefix:
```
Experimenting I find that `os.path.normpath` always returns a non-empty string.
```
>>> import os
>>> os.path.normpath("")
'.'
>>> os.path.normpath("/")
'/'
>>> os.path.normpath(".")
'.'
>>> os.path.normpath("..")
'..'
>>> os.path.normpath("a")
'a'
```
So the `if` condition would always be true, and can therefore be removed.

2.
`prefix` is run through `os.path.join` and then used as the `subdir` argument to `_add_directory`.
https://github.com/python-pillow/Pillow/blob/e5415ca082e9dbecb5f1c21650303b680ce6cadd/setup.py#L206-L209
```python
def _add_directory(path, subdir, where=None):
    if subdir is None:
        return
    subdir = os.path.realpath(subdir)
```
So it is immediately run through `os.path.realpath`. I find that the intended manipulations of `os.path.normpath` -

https://docs.python.org/3/library/os.path.html#os.path.normpath
> os.path.normpath(path)
> Normalize a pathname by collapsing redundant separators and up-level references so that A//B, A/B/, A/./B and A/foo/../B all become A/B. This string manipulation may change the meaning of a path that contains symbolic links. On Windows, it converts forward slashes to backward slashes.

are all also performed by `os.path.realpath` - making `os.path.normpath` unnecessary.

```
>>> import os
>>> os.path.normpath("A//B")
'A/B'
>>> os.path.normpath("A/B/")
'A/B'
>>> os.path.normpath("A/./B")
'A/B'
>>> os.path.normpath("A/foo/../B")
'A/B'
>>> os.path.realpath("A//B")
'/Users/andrewmurray/A/B'
>>> os.path.normpath("A/B/")
'A/B'
>>> os.path.normpath("A/./B")
'A/B'
>>> os.path.normpath("A/foo/../B")
'A/B'
```