### PR TITLE
Simplify ImageCms links in docs

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -94,13 +94,13 @@ they issued a ``DeprecationWarning``:
 ========================  ===============================================================
 Removed                   Use instead
 ========================  ===============================================================
-``color_space``           Padded :py:attr:`~PIL.ImageCms.CmsProfile.xcolor_space`
-``pcs``                   Padded :py:attr:`~PIL.ImageCms.CmsProfile.connection_space`
-``product_copyright``     Unicode :py:attr:`~PIL.ImageCms.CmsProfile.copyright`
-``product_desc``          Unicode :py:attr:`~PIL.ImageCms.CmsProfile.profile_description`
-``product_description``   Unicode :py:attr:`~PIL.ImageCms.CmsProfile.profile_description`
-``product_manufacturer``  Unicode :py:attr:`~PIL.ImageCms.CmsProfile.manufacturer`
-``product_model``         Unicode :py:attr:`~PIL.ImageCms.CmsProfile.model`
+``color_space``           Padded :py:attr:`~.CmsProfile.xcolor_space`
+``pcs``                   Padded :py:attr:`~.CmsProfile.connection_space`
+``product_copyright``     Unicode :py:attr:`~.CmsProfile.copyright`
+``product_desc``          Unicode :py:attr:`~.CmsProfile.profile_description`
+``product_description``   Unicode :py:attr:`~.CmsProfile.profile_description`
+``product_manufacturer``  Unicode :py:attr:`~.CmsProfile.manufacturer`
+``product_model``         Unicode :py:attr:`~.CmsProfile.model`
 ========================  ===============================================================
 
 Python 2.7

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -91,9 +91,10 @@ ImageCms.CmsProfile attributes
 Some attributes in :py:class:`PIL.ImageCms.CmsProfile` have been removed. From 6.0.0,
 they issued a ``DeprecationWarning``:
 
-========================  ===============================================================
+========================  ===================================================
+
 Removed                   Use instead
-========================  ===============================================================
+========================  ===================================================
 ``color_space``           Padded :py:attr:`~.CmsProfile.xcolor_space`
 ``pcs``                   Padded :py:attr:`~.CmsProfile.connection_space`
 ``product_copyright``     Unicode :py:attr:`~.CmsProfile.copyright`
@@ -101,7 +102,7 @@ Removed                   Use instead
 ``product_description``   Unicode :py:attr:`~.CmsProfile.profile_description`
 ``product_manufacturer``  Unicode :py:attr:`~.CmsProfile.manufacturer`
 ``product_model``         Unicode :py:attr:`~.CmsProfile.model`
-========================  ===============================================================
+========================  ===================================================
 
 Python 2.7
 ~~~~~~~~~~

--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -29,13 +29,13 @@ Some attributes in :py:class:`PIL.ImageCms.CmsProfile` have been removed:
 ========================  ===============================================================
 Removed                   Use instead
 ========================  ===============================================================
-``color_space``           Padded :py:attr:`~PIL.ImageCms.CmsProfile.xcolor_space`
-``pcs``                   Padded :py:attr:`~PIL.ImageCms.CmsProfile.connection_space`
-``product_copyright``     Unicode :py:attr:`~PIL.ImageCms.CmsProfile.copyright`
-``product_desc``          Unicode :py:attr:`~PIL.ImageCms.CmsProfile.profile_description`
-``product_description``   Unicode :py:attr:`~PIL.ImageCms.CmsProfile.profile_description`
-``product_manufacturer``  Unicode :py:attr:`~PIL.ImageCms.CmsProfile.manufacturer`
-``product_model``         Unicode :py:attr:`~PIL.ImageCms.CmsProfile.model`
+``color_space``           Padded :py:attr:`~.CmsProfile.xcolor_space`
+``pcs``                   Padded :py:attr:`~.CmsProfile.connection_space`
+``product_copyright``     Unicode :py:attr:`~.CmsProfile.copyright`
+``product_desc``          Unicode :py:attr:`~.CmsProfile.profile_description`
+``product_description``   Unicode :py:attr:`~.CmsProfile.profile_description`
+``product_manufacturer``  Unicode :py:attr:`~.CmsProfile.manufacturer`
+``product_model``         Unicode :py:attr:`~.CmsProfile.model`
 ========================  ===============================================================
 
 API Changes

--- a/docs/releasenotes/8.0.0.rst
+++ b/docs/releasenotes/8.0.0.rst
@@ -26,9 +26,9 @@ ImageCms.CmsProfile attributes
 
 Some attributes in :py:class:`PIL.ImageCms.CmsProfile` have been removed:
 
-========================  ===============================================================
+========================  ===================================================
 Removed                   Use instead
-========================  ===============================================================
+========================  ===================================================
 ``color_space``           Padded :py:attr:`~.CmsProfile.xcolor_space`
 ``pcs``                   Padded :py:attr:`~.CmsProfile.connection_space`
 ``product_copyright``     Unicode :py:attr:`~.CmsProfile.copyright`
@@ -36,7 +36,7 @@ Removed                   Use instead
 ``product_description``   Unicode :py:attr:`~.CmsProfile.profile_description`
 ``product_manufacturer``  Unicode :py:attr:`~.CmsProfile.manufacturer`
 ``product_model``         Unicode :py:attr:`~.CmsProfile.model`
-========================  ===============================================================
+========================  ===================================================
 
 API Changes
 ===========


### PR DESCRIPTION
Suggestion for python-pillow/Pillow#4845:

* Use shorter links to make the `.rst` files easier to read.

From https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#cross-referencing-python-objects (emphasis mine):

>Also, if the name is prefixed with a dot, and no exact match is found, the target is taken as a suffix and all object names with that suffix are searched. For example, :py:meth:`.TarFile.close` references the tarfile.TarFile.close() function, even if the current module is not tarfile. **Since this can get ambiguous, if there is more than one possible match, you will get a warning from Sphinx.**
>
>**Note that you can combine the ~ and . prefixes: :py:meth:`~.TarFile.close` will reference the tarfile.TarFile.close() method, but the visible link caption will only be close().**