### PR TITLE
Do not require packaging just for a DeprecationWarning

### DIFF
--- a/src/PIL/ImageFont.py
+++ b/src/PIL/ImageFont.py
@@ -31,8 +31,6 @@ import sys
 import warnings
 from io import BytesIO
 
-from packaging.version import parse as parse_version
-
 from . import Image, features
 from ._util import isDirectory, isPath
 
@@ -167,14 +165,20 @@ class FreeTypeFont:
         self.index = index
         self.encoding = encoding
 
-        freetype_version = parse_version(features.version_module("freetype2"))
-        if freetype_version < parse_version("2.8"):
-            warnings.warn(
-                "Support for FreeType 2.7 is deprecated and will be removed in Pillow "
-                "9 (2022-01-02). Please upgrade to FreeType 2.8 or newer, preferably "
-                "FreeType 2.10.4 which fixes CVE-2020-15999.",
-                DeprecationWarning,
-            )
+        try:
+            from packaging.version import parse as parse_version
+        except ImportError:
+            pass
+        else:
+            freetype_version = parse_version(features.version_module("freetype2"))
+            if freetype_version < parse_version("2.8"):
+                warnings.warn(
+                    "Support for FreeType 2.7 is deprecated and will be removed"
+                    " in Pillow 9 (2022-01-02). Please upgrade to FreeType 2.8 "
+                    "or newer, preferably FreeType 2.10.4 which fixes "
+                    "CVE-2020-15999.",
+                    DeprecationWarning,
+                )
 
         if layout_engine not in (LAYOUT_BASIC, LAYOUT_RAQM):
             layout_engine = LAYOUT_BASIC


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/5098

In the PR, `packaging` is used to check the FreeType version. However, `packaging` isn't necessarily installed. Instead of adding a requirement for a new module just to allow users to see a DeprecationWarning if they have an older FreeType, this PR just abandons the DeprecationWarning if `packaging` is not installed.