### PR TITLE
Fix 3rd level menu item background-color in dark mode

### DIFF
--- a/docs/resources/css/dark.css
+++ b/docs/resources/css/dark.css
@@ -1196,6 +1196,7 @@
         color: rgb(166, 158, 146);
     }
 
+    .wy-menu-vertical li.toctree-l2.current a,
     .wy-menu-vertical li.toctree-l3.current a {
         background-color: #363636;
     }

--- a/docs/resources/css/light.css
+++ b/docs/resources/css/light.css
@@ -1,5 +1,6 @@
 @media (prefers-color-scheme: light) {
 
+    .wy-menu-vertical li.toctree-l2.current a,
     .wy-menu-vertical li.toctree-l3.current a {
         background-color: #c9c9c9;
     }

--- a/docs/resources/js/script.js
+++ b/docs/resources/js/script.js
@@ -24,7 +24,6 @@ jQuery(document).ready(function ($) {
                     var $upperA = $sidebarItem.parent().children('a');
                     var $upperAParent = $upperA.parent();
                     if ($upperAParent.hasClass('toctree-l2')) {
-                        $a.css('background-color', '#c9c9c9');
                         $a.css('padding-left', '4em');
                     } else if ($upperAParent.hasClass('toctree-l3')) {
                         if (!$upperA.find('.toctree-expand').length) {


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/5056

While we're there, fix 3rd level menu item - see https://pillow--5056.org.readthedocs.build/en/5056/reference/ImageShow.html in dark mode, vs https://pillow-radarhere.readthedocs.io/en/fix-4th-level-menu-dark-mode/reference/ImageShow.html