### PR TITLE
Set og:image:alt to be constant

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -324,3 +324,4 @@ ogp_image = (
     "https://raw.githubusercontent.com/python-pillow/pillow-logo/master/"
     "pillow-logo-dark-text-1280x640.png"
 )
+ogp_image_alt = "Pillow"


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/pull/5498

https://pillow--5498.org.readthedocs.build/en/5498/handbook/tutorial.html lists 'og:image:alt' as 'Tutorial'.

That doesn't seem right to me.

This PR makes it 'Pillow' everywhere - https://pillow-radarhere.readthedocs.io/en/improve-docs/handbook/tutorial.html