### PR TITLE
Use python3 to run and install commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ release-test:
 	-rm dist/*.egg
 	-rmdir dist
 	python3 -m pytest -qq
-	check-manifest
-	pyroma .
+	python3 -m check-manifest
+	python3 -m pyroma .
 	$(MAKE) readme
 
 .PHONY: sdist
@@ -92,7 +92,7 @@ sdist:
 
 .PHONY: test
 test:
-	pytest -qq
+	python3 -m pytest -qq
 
 .PHONY: valgrind
 valgrind:
@@ -103,15 +103,15 @@ valgrind:
 
 .PHONY: readme
 readme:
-	markdown2 README.md > .long-description.html && open .long-description.html
+	python3 -m markdown2 README.md > .long-description.html && open .long-description.html
 
 
 .PHONY: lint
 lint:
-	tox --help > /dev/null || python3 -m pip install tox
-	tox -e lint
+	python3 -c "import tox" || python3 -m pip install tox
+	python3 -m tox -e lint
 
 .PHONY: lint-fix
 lint-fix:
-	black --target-version py37 .
-	isort .
+	python3 -m black --target-version py37 .
+	python3 -m isort .

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ sdist:
 
 .PHONY: test
 test:
+	python3 -c "import pytest" || python3 -m pip install pytest
 	python3 -m pytest -qq
 
 .PHONY: valgrind
@@ -103,6 +104,7 @@ valgrind:
 
 .PHONY: readme
 readme:
+	python3 -c "import markdown2" || python3 -m pip install markdown2
 	python3 -m markdown2 README.md > .long-description.html && open .long-description.html
 
 
@@ -113,5 +115,7 @@ lint:
 
 .PHONY: lint-fix
 lint-fix:
+	python3 -c "import black" || python3 -m pip install black
+	python3 -c "import isort" || python3 -m pip install isort
 	python3 -m black --target-version py37 .
 	python3 -m isort .


### PR DESCRIPTION
An idea to invoke more commands in Makefile through python3, rather than by themselves.

Considering
https://github.com/hugovk/Pillow/blob/75028b6f9369801bd8b973ccbb441abab4036a1c/Makefile#L77
this seems like it could prevent installing a setup.cfg requirement, only to have a different version later used by the Makefile.

I'm copying part of this idea from
https://github.com/hugovk/Pillow/blob/75028b6f9369801bd8b973ccbb441abab4036a1c/Makefile#L99