### PR TITLE
If removal version has arrived, raise an error

### DIFF
--- a/Tests/test_deprecate.py
+++ b/Tests/test_deprecate.py
@@ -29,6 +29,27 @@ def test_unknown_version():
         _deprecate.deprecate("Old thing", 12345, "new thing")
 
 
+@pytest.mark.parametrize(
+    "deprecated, plural, expected",
+    [
+        (
+            "Old thing",
+            False,
+            r"Old thing is deprecated and should be removed\.",
+        ),
+        (
+            "Old things",
+            True,
+            r"Old things are deprecated and should be removed\.",
+        ),
+    ],
+)
+def test_old_version(deprecated, plural, expected):
+    expected = r""
+    with pytest.raises(RuntimeError, match=expected):
+        _deprecate.deprecate(deprecated, 1, plural=plural)
+
+
 def test_plural():
     expected = (
         r"Old things are deprecated and will be removed in Pillow 10 \(2023-07-01\)\. "

--- a/src/PIL/_deprecate.py
+++ b/src/PIL/_deprecate.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import warnings
 
+from . import __version__
+
 
 def deprecate(
     deprecated: str,
@@ -38,10 +40,12 @@ def deprecate(
 
     is_ = "are" if plural else "is"
 
-    if when == 10:
-        removed = "Pillow 10 (2023-07-01)"
-    elif when is None:
+    if when is None:
         removed = "a future version"
+    elif when <= int(__version__.split(".")[0]):
+        raise RuntimeError(f"{deprecated} {is_} deprecated and should be removed.")
+    elif when == 10:
+        removed = "Pillow 10 (2023-07-01)"
     else:
         raise ValueError(f"Unknown removal version, update {__name__}?")
 


### PR DESCRIPTION
An idea for https://github.com/python-pillow/Pillow/pull/6184. Feel free to disregard if you want, as it is rather theoretical.

What if we managed to accidentally leave in a Pillow 10 deprecation warning for the Pillow 10 release?
Users would then be told that the feature would be removed in Pillow 10, with a date in the past, which would introduce confusion.
Or worse, we might have removed the `when == 10` condition, and they would receive a ValueError.
Instead, we could switch to the generic statement that it would be removed in "a future version".