### PR TITLE
Changed indentation to be consistent

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -205,11 +205,11 @@ Many of Pillow's features require external libraries:
 
     In Fedora, the command is::
 
-       sudo dnf install python3-devel redhat-rpm-config
+        sudo dnf install python3-devel redhat-rpm-config
 
     In Alpine, the command is::
 
-       sudo apk add python3-dev py3-setuptools
+        sudo apk add python3-dev py3-setuptools
 
     .. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/6764

The indentation for "In Fedora, the command is" and "In Alpine, the command is" does not match the indentation for "In Debian or Ubuntu".