### PR TITLE
Raise ValueError during filter operation as well

### DIFF
--- a/Tests/test_image_filter.py
+++ b/Tests/test_image_filter.py
@@ -179,3 +179,9 @@ def test_consistency_5x5(mode):
 def test_invalid_box_blur_filter():
     with pytest.raises(ValueError):
         ImageFilter.BoxBlur(-2)
+
+    im = hopper()
+    box_blur_filter = ImageFilter.BoxBlur(2)
+    box_blur_filter.radius = -2
+    with pytest.raises(ValueError):
+        im.filter(box_blur_filter)

--- a/src/libImaging/BoxBlur.c
+++ b/src/libImaging/BoxBlur.c
@@ -237,6 +237,9 @@ ImagingBoxBlur(Imaging imOut, Imaging imIn, float radius, int n) {
     if (n < 1) {
         return ImagingError_ValueError("number of passes must be greater than zero");
     }
+    if (radius < 0) {
+        return ImagingError_ValueError("radius must be >= 0");
+    }
 
     if (strcmp(imIn->mode, imOut->mode) || imIn->type != imOut->type ||
         imIn->bands != imOut->bands || imIn->xsize != imOut->xsize ||


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/6874

Other ways to trigger the problem are
```python
import numpy as np
from PIL import Image, ImageFilter

img = Image.fromarray(np.ones([100, 100, 3], dtype='uint8'))
blur = ImageFilter.BoxBlur(2)
blur.radius = -2
img = img.filter(blur)
```

You could also abuse ``getdata()`` to access the C api directly, but that's less legitimate.
```python
import numpy as np
from PIL import Image, ImageFilter

img = Image.fromarray(np.ones([100, 100, 3], dtype='uint8'))
img = img.getdata().box_blur(-2)
```

This PR raises an error from C if a negative radius is used after initialisation of the filter to prevent those scenarios.