### PR TITLE
add gcov coverage to test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,9 +107,9 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@v3
       with:
-        file: ./coverage.xml
         flags: ${{ matrix.os == 'macos-latest' && 'GHA_macOS' || 'GHA_Ubuntu' }}
         name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+        gcov: true
 
   success:
     permissions:


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/pull/6944

I found that removing the `file` filter allows CodeCov to detect the gcov files.