### PR TITLE
Remove deprecations for Pillow 10.0.0

### DIFF
--- a/Tests/test_qt_image_toqimage.py
+++ b/Tests/test_qt_image_toqimage.py
@@ -28,7 +28,7 @@ def test_sanity(mode, tmp_path):
         assert_image_equal(rt, src)
 
     if mode == "1":
-        # BW appears to not save correctly on QT
+        # BW appears to not save correctly on Qt
         # kicks out errors on console:
         #     libpng warning: Invalid color type/bit depth combination
         #                     in IHDR

--- a/Tests/test_qt_image_toqimage.py
+++ b/Tests/test_qt_image_toqimage.py
@@ -28,7 +28,7 @@ def test_sanity(mode, tmp_path):
         assert_image_equal(rt, src)
 
     if mode == "1":
-        # BW appears to not save correctly on QT5
+        # BW appears to not save correctly on QT
         # kicks out errors on console:
         #     libpng warning: Invalid color type/bit depth combination
         #                     in IHDR

--- a/docs/reference/Image.rst
+++ b/docs/reference/Image.rst
@@ -412,18 +412,6 @@ See :ref:`concept-filters` for details.
     :undoc-members:
     :noindex:
 
-Some deprecated filters are also available under the following names:
-
-.. data:: NONE
-    :noindex:
-    :value: Resampling.NEAREST
-.. data:: LINEAR
-    :value: Resampling.BILINEAR
-.. data:: CUBIC
-    :value: Resampling.BICUBIC
-.. data:: ANTIALIAS
-    :value: Resampling.LANCZOS
-
 Dither modes
 ^^^^^^^^^^^^
 

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -487,7 +487,6 @@ class Image:
         self._size = (0, 0)
         self.palette = None
         self.info = {}
-        self._category = 0
         self.readonly = 0
         self.pyaccess = None
         self._exif = None
@@ -604,7 +603,6 @@ class Image:
             and self.mode == other.mode
             and self.size == other.size
             and self.info == other.info
-            and self._category == other._category
             and self.getpalette() == other.getpalette()
             and self.tobytes() == other.tobytes()
         )

--- a/src/PIL/MicImagePlugin.py
+++ b/src/PIL/MicImagePlugin.py
@@ -66,9 +66,6 @@ class MicImageFile(TiffImagePlugin.TiffImageFile):
         self._n_frames = len(self.images)
         self.is_animated = self._n_frames > 1
 
-        if len(self.images) > 1:
-            self._category = Image.CONTAINER
-
         self.seek(0)
 
     def seek(self, frame):


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/7059

- Update a comment that part of our test code fails on Qt5, as [it still fails with Qt6](https://github.com/radarhere/Pillow/actions/runs/4642710805/jobs/8216843788).
- Removed `_category` in connection to https://github.com/python-pillow/Pillow/pull/5351
- In connection to https://github.com/python-pillow/Pillow/pull/5954 / https://github.com/python-pillow/Pillow/pull/6830, removed documentation