### PR TITLE
Restrict "params" to list or None

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -41,14 +41,9 @@ def cmd_rmdir(path: str) -> str:
 def cmd_nmake(
     makefile: str | None = None,
     target: str = "",
-    params: str | list[str] | tuple[str, ...] = None,
+    params: list[str] | None = None,
 ) -> str:
-    if params is None:
-        params = ""
-    elif isinstance(params, (list, tuple)):
-        params = " ".join(params)
-    else:
-        params = str(params)
+    params = "" if params is None else " ".join(params)
 
     return " ".join(
         [


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7407

In your PR at the moment,
```python
def cmd_nmake(
    makefile: str | None = None,
    target: str = "",
    params: str | list[str] | tuple[str, ...] = None,
) -> str:
    if params is None:
        params = ""
    elif isinstance(params, (list, tuple)):
        params = " ".join(params)
    else:
        params = str(params)
```
`params` is either a string, list or tuple. When it is a string, `str(params)` is called? I find this odd, since it is already a string.

`cmd_nmake` is only called either without the third argument, or with a list, so maybe the simplest solution is just to restrict it to those two options?