### PR TITLE
Do not test for iOS

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,6 +166,8 @@ html_static_path = ["resources"]
 # directly to the root of the documentation.
 # html_extra_path = []
 
+html_css_files = ["css/dark.css"]
+
 html_js_files = [
     "js/activate_tab.js",
 ]
@@ -315,10 +317,6 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
-
-
-def setup(app):
-    app.add_css_file("css/dark.css")
 
 
 linkcheck_allowed_redirects = {

--- a/docs/resources/js/activate_tab.js
+++ b/docs/resources/js/activate_tab.js
@@ -1,16 +1,12 @@
 // Based on https://stackoverflow.com/a/38241481/724176
 function getOS() {
   const userAgent = window.navigator.userAgent,
-    platform =
-      window.navigator?.userAgentData?.platform || window.navigator.platform,
+    platform = window.navigator?.userAgentData?.platform || window.navigator.platform,
     macosPlatforms = ["macOS", "Macintosh", "MacIntel", "MacPPC", "Mac68K"],
-    windowsPlatforms = ["Win32", "Win64", "Windows", "WinCE"],
-    iosPlatforms = ["iPhone", "iPad", "iPod"];
+    windowsPlatforms = ["Win32", "Win64", "Windows", "WinCE"];
 
   if (macosPlatforms.includes(platform)) {
     return "macOS";
-  } else if (iosPlatforms.includes(platform)) {
-    return "iOS";
   } else if (windowsPlatforms.includes(platform)) {
     return "Windows";
   } else if (/Android/.test(userAgent)) {
@@ -18,8 +14,6 @@ function getOS() {
   } else if (/Linux/.test(platform)) {
     return "Linux";
   }
-
-  return "unknown";
 }
 
 function activateTab(tabName) {
@@ -28,7 +22,7 @@ function activateTab(tabName) {
 
   labels.forEach((label) => {
     if (label.textContent == tabName) {
-      // Find the associated input element using the 'for' attribute
+      // Find the associated input element using the "for" attribute
       const tabInputId = label.getAttribute("for");
       const tabInput = document.getElementById(tabInputId);
 

--- a/docs/resources/js/activate_tab.js
+++ b/docs/resources/js/activate_tab.js
@@ -1,7 +1,7 @@
 // Based on https://stackoverflow.com/a/38241481/724176
 function getOS() {
   const userAgent = window.navigator.userAgent,
-    platform = window.navigator?.userAgentData?.platform || window.navigator.platform,
+    platform = window.navigator.userAgentData?.platform || window.navigator.platform,
     macosPlatforms = ["macOS", "Macintosh", "MacIntel", "MacPPC", "Mac68K"],
     windowsPlatforms = ["Win32", "Win64", "Windows", "WinCE"];
 

--- a/docs/resources/js/activate_tab.js
+++ b/docs/resources/js/activate_tab.js
@@ -23,7 +23,7 @@ function getOS() {
 }
 
 function activateTab(tabName) {
-  // Find all label elements containing the specified tab name
+  // Find all label elements with the specified tab name
   const labels = document.querySelectorAll(".tab-label");
 
   labels.forEach((label) => {


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/7579

- Do not test for iOS. We don't have an iOS tab
- Update a comment now that we're no longer searching for text "containing" the OS
- `window.navigator?.userAgentData` is used, after `window.navigator.userAgent` is used. So there's no point having the second `window.navigatior` be optional
- You've introduced `html_js_files`, so I've moved the existing CSS file into `html_css_files`