### PR TITLE
Combine build steps

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           # Build only the currently selected Linux architecture (so we can
           # parallelise for speed).
-          CIBW_ARCHS_LINUX: "aarch64"
+          CIBW_ARCHS: "aarch64"
           # Likewise, select only one Python version per job to speed this up.
           CIBW_BUILD: "${{ matrix.python-version }}-manylinux*"
           # Extra options for manylinux.
@@ -90,7 +90,7 @@ jobs:
         env:
           # Build only the currently selected Linux architecture (so we can
           # parallelise for speed).
-          CIBW_ARCHS_LINUX: "aarch64"
+          CIBW_ARCHS: "aarch64"
           # Likewise, select only one Python version per job to speed this up.
           CIBW_BUILD: "${{ matrix.python-version }}-${{ matrix.spec }}*"
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -124,6 +124,7 @@ jobs:
           python3 -m pip install -r .ci/requirements-cibw.txt
 
       - name: Build wheels
+        run: |
           python3 -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS: ${{ matrix.cibw_arch }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          & python.exe -m pip install -r .ci/requirements-cibw.txt
+          python.exe -m pip install -r .ci/requirements-cibw.txt
 
       - name: Prepare for build
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -69,8 +69,7 @@ jobs:
         run: |
           python3 -m pip install -r .ci/requirements-cibw.txt
 
-      - name: Build wheels (manylinux)
-        if: matrix.spec != 'musllinux'
+      - name: Build wheels
         run: |
           python3 -m cibuildwheel --output-dir wheelhouse
         env:
@@ -78,21 +77,10 @@ jobs:
           # parallelise for speed).
           CIBW_ARCHS: "aarch64"
           # Likewise, select only one Python version per job to speed this up.
-          CIBW_BUILD: "${{ matrix.python-version }}-manylinux*"
+          CIBW_BUILD: "${{ matrix.python-version }}-${{ matrix.spec == 'musllinux' && 'musllinux' || 'manylinux' }}*"
           # Extra options for manylinux.
           CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.spec }}
           CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: ${{ matrix.spec }}
-
-      - name: Build wheels (musllinux)
-        if: matrix.spec == 'musllinux'
-        run: |
-          python3 -m cibuildwheel --output-dir wheelhouse
-        env:
-          # Build only the currently selected Linux architecture (so we can
-          # parallelise for speed).
-          CIBW_ARCHS: "aarch64"
-          # Likewise, select only one Python version per job to speed this up.
-          CIBW_BUILD: "${{ matrix.python-version }}-${{ matrix.spec }}*"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -119,9 +119,11 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Build wheels
+      - name: Install cibuildwheel
         run: |
           python3 -m pip install -r .ci/requirements-cibw.txt
+
+      - name: Build wheels
           python3 -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS: ${{ matrix.cibw_arch }}
@@ -163,6 +165,10 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install cibuildwheel
+        run: |
+          & python.exe -m pip install -r .ci/requirements-cibw.txt
+
       - name: Prepare for build
         run: |
           choco install nasm --no-progress
@@ -170,8 +176,6 @@ jobs:
 
           # Install extra test images
           xcopy /S /Y Tests\test-images\* Tests\images
-
-          & python.exe -m pip install -r .ci/requirements-cibw.txt
 
           & python.exe winbuild\build_prepare.py -v --no-imagequant --architecture=${{ matrix.arch }}
         shell: pwsh


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/7690

- Use the shorter, and more general, `CIBW_ARCHS` instead of `CIBW_ARCHS_LINUX`
- Combine build steps by including a condition in env variables