### PR TITLE
Simplified anchors

### DIFF
--- a/docs/installation/basic-installation.rst
+++ b/docs/installation/basic-installation.rst
@@ -76,7 +76,7 @@ and :pypi:`olefile` for Pillow to read FPX and MIC images::
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade Pillow
 
-    To install Pillow in MSYS2, see :ref:`Building on Windows using MSYS2/MinGW`.
+    To install Pillow in MSYS2, see :ref:`building-from-source`.
 
 .. tab:: FreeBSD
 

--- a/docs/installation/building-from-source.rst
+++ b/docs/installation/building-from-source.rst
@@ -6,12 +6,6 @@
     });
     </script>
 
-.. _Building on Linux:
-.. _Building on macOS:
-.. _Building on Windows:
-.. _Building on Windows using MSYS2/MinGW:
-.. _Building on FreeBSD:
-.. _Building on Android:
 .. _building-from-source:
 
 Building From Source

--- a/docs/installation/python-support.rst
+++ b/docs/installation/python-support.rst
@@ -12,8 +12,3 @@ Pillow supports these Python versions.
 .. csv-table:: Older versions
    :file: older-versions.csv
    :header-rows: 1
-
-.. _Linux Installation:
-.. _macOS Installation:
-.. _Windows Installation:
-.. _FreeBSD Installation:


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7858

```
.. _Building on Linux:
.. _Building on macOS:
.. _Building on Windows:
.. _Building on Windows using MSYS2/MinGW:
.. _Building on FreeBSD:
.. _Building on Android:
```
and
```
.. _Linux Installation:
.. _macOS Installation:
.. _Windows Installation:
.. _FreeBSD Installation:
```
are anchors that were added in https://github.com/python-pillow/Pillow/commit/e3a46fcfd0111d7f080da0efe5846 to replace headings.

I think they're not needed in these new locations. If someone was linking to https://pillow.readthedocs.io/en/stable/installation.html#building-on-windows-using-msys2-mingw, it's not going to do any good for us to add that anchor at building-from-source.html, as it's a different page.