### PR TITLE
Check GIL, rather than Python version

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -38,7 +38,7 @@ python3 -m pip install pyroma
 
 if [[ $(uname) != CYGWIN* ]]; then
     # TODO Update condition when NumPy supports free-threading
-    if [[ "$GHA_PYTHON_VERSION" == "3.13-dev" ]]; then
+    if [[ "$PYTHON_GIL" == "0" ]]; then
         python3 -m pip install numpy --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     else
         python3 -m pip install numpy
@@ -48,7 +48,7 @@ if [[ $(uname) != CYGWIN* ]]; then
     if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
         sudo apt-get -qq install libegl1 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxkbcommon-x11-0
         # TODO Update condition when pyqt6 supports free-threading
-        if ! [[ "$GHA_PYTHON_VERSION" == "3.13-dev" ]]; then python3 -m pip install pyqt6 ; fi
+        if ! [[ "$PYTHON_GIL" == "0" ]]; then python3 -m pip install pyqt6 ; fi
     fi
 
     # Pyroma uses non-isolated build and fails with old setuptools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
-      if: "!endsWith(matrix.python-version, '-dev')"
+      if: "${{ !matrix.disable-gil }}"
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -78,7 +78,7 @@ jobs:
 
     - name: Set up Python ${{ matrix.python-version }} (free-threaded)
       uses: deadsnakes/action@v3.1.0
-      if: endsWith(matrix.python-version, '-dev')
+      if: "${{ matrix.disable-gil }}"
       with:
         python-version: ${{ matrix.python-version }}
         nogil: ${{ matrix.disable-gil }}


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/8200

At the moment, 3.13-dev installs 3.13.0b2+, and 3.13 installs 3.13.0b2.

In a few months, 3.13-dev will become the same as 3.13. So it seems to me we can just remove the '-dev' suffix now and get it over with.