### PR TITLE
Group 11.0.0 deprecations

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -12,19 +12,6 @@ Deprecated features
 Below are features which are considered deprecated. Where appropriate,
 a :py:exc:`DeprecationWarning` is issued.
 
-FreeType 2.9.0
-~~~~~~~~~~~~~~
-
-.. deprecated:: 11.0.0
-
-Support for FreeType 2.9.0 is deprecated and will be removed in Pillow 12.0.0
-(2025-10-15), when FreeType 2.9.1 will be the minimum supported.
-
-We recommend upgrading to at least FreeType `2.10.4`_, which fixed a severe
-vulnerability introduced in FreeType 2.6 (:cve:`2020-15999`).
-
-.. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
-
 ImageFile.raise_oserror
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -121,6 +108,19 @@ ImageDraw.getdraw hints parameter
 .. deprecated:: 10.4.0
 
 The ``hints`` parameter in :py:meth:`~PIL.ImageDraw.getdraw()` has been deprecated.
+
+FreeType 2.9.0
+~~~~~~~~~~~~~~
+
+.. deprecated:: 11.0.0
+
+Support for FreeType 2.9.0 is deprecated and will be removed in Pillow 12.0.0
+(2025-10-15), when FreeType 2.9.1 will be the minimum supported.
+
+We recommend upgrading to at least FreeType `2.10.4`_, which fixed a severe
+vulnerability introduced in FreeType 2.6 (:cve:`2020-15999`).
+
+.. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
 
 ImageMath.lambda_eval and ImageMath.unsafe_eval options parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/8356

The deprecations are currently sorted with the most recent at the bottom.