### PR TITLE
Require coverage>=7.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ optional-dependencies.mic = [
 ]
 optional-dependencies.tests = [
   "check-manifest",
-  "coverage",
+  "coverage>=7.4.2",
   "defusedxml",
   "markdown2",
   "olefile",


### PR DESCRIPTION
https://github.com/python-pillow/Pillow/pull/8514#discussion_r1831341942
> coverage vs coverage>=7.4.2: before, theoretically we could have installed coverage older than 7.4.2 here. I think that was unlikely and it's safer to require the newer version.

I'm a little confused, because the current state of the PR relaxes the coverage requirement, but

> But if we want to run it, trove-classifiers>=2024.10.12 is a required dependency. We shouldn't really just hope we end up with a newer one installed into the system.

is an argument that we shouldn't relax requirements?

This PR requires coverage>=7.4.2 in pyproject.toml, to be consistent.