### PR TITLE
Remove pyroma and check-manifest dependencies

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -31,7 +31,6 @@ python3 -m pip install olefile
 python3 -m pip install -U pytest
 python3 -m pip install -U pytest-cov
 python3 -m pip install -U pytest-timeout
-python3 -m pip install pyroma
 # optional test dependencies, only install if there's a binary package.
 python3 -m pip install --only-binary=:all: numpy || true
 python3 -m pip install --only-binary=:all: pyarrow || true

--- a/.github/workflows/macos-install.sh
+++ b/.github/workflows/macos-install.sh
@@ -12,7 +12,6 @@ python3 -m pip install olefile
 python3 -m pip install -U pytest
 python3 -m pip install -U pytest-cov
 python3 -m pip install -U pytest-timeout
-python3 -m pip install pyroma
 # optional test dependencies, only install if there's a binary package.
 python3 -m pip install --only-binary=:all: numpy || true
 python3 -m pip install --only-binary=:all: pyarrow || true

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,6 @@ release-test:
 	python3 -m pytest Tests
 	python3 -m pip install .
 	python3 -m pytest -qq
-	python3 -m pyroma .
 	$(MAKE) readme
 
 .PHONY: sdist

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -260,6 +260,7 @@ class TestEmbeddable:
     @pytest.mark.xfail(not (sys.version_info >= (3, 13)), reason="failing test")
     @pytest.mark.skipif(not is_win32(), reason="requires Windows")
     def test_embeddable(self) -> None:
+        pytest.importorskip("setuptools", reason="setuptools not installed")
         import ctypes
 
         from setuptools.command import build_ext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ optional-dependencies.tests = [
   "pytest-cov",
   "pytest-timeout",
   "pytest-xdist",
+  "setuptools",
   "trove-classifiers>=2024.10.12",
 ]
 optional-dependencies.xmp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ optional-dependencies.tests = [
   "markdown2",
   "olefile",
   "packaging",
-  "pyroma>=5",
   "pytest",
   "pytest-cov",
   "pytest-timeout",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ optional-dependencies.test-arrow = [
   "pyarrow",
 ]
 optional-dependencies.tests = [
-  "check-manifest",
   "coverage>=7.4.2",
   "defusedxml",
   "markdown2",


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/9670

I've removed pyroma and check-manifest as dependencies in locations other than pre-commit.

However, it seems this was also installing setuptools - https://github.com/hugovk/Pillow/actions/runs/27466538461/job/81189741200 - so I've added that explicitly.